### PR TITLE
Improve front view zoom and ingestion fallback

### DIFF
--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -72,19 +72,24 @@ export async function POST(req: NextRequest) {
     content: e.getData().toString('utf8').slice(0, 10000)
   }))
 
+  const defaultAnalysis = {
+    overview: '',
+    takeaways: [],
+    metrics: { complexity: 0, documentation: 0, tests: 0 }
+  }
+  let analysis = defaultAnalysis
   try {
-    const analysis = await summarizeRepo(files, docs)
-    return NextResponse.json({
-      repo,
-      branch,
-      files,
-      code,
-      docs,
-      analysis
-    })
+    analysis = await summarizeRepo(files, docs)
   } catch (err) {
     const message = err instanceof Error ? err.message : 'analysis failed'
     console.error('analysis failed', err)
-    return NextResponse.json({ error: message }, { status: 500 })
   }
+  return NextResponse.json({
+    repo,
+    branch,
+    files,
+    code,
+    docs,
+    analysis
+  })
 }

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -91,9 +91,19 @@ export default function IngestPage() {
           return [b, Array.isArray(j) ? j : []]
         })
       )
+      const domains: Record<string, string> = {}
+      brData.forEach((d: any) => {
+        if (d.domain) domains[d.name] = d.domain
+      })
       localStorage.setItem(
         'trackingData',
-        JSON.stringify({ branches: names, offsets, data: Object.fromEntries(entries) })
+        JSON.stringify({
+          repo,
+          branches: names,
+          offsets,
+          domains,
+          data: Object.fromEntries(entries)
+        })
       )
     } catch {
       /* ignore prefetch errors */
@@ -173,6 +183,7 @@ export default function IngestPage() {
         localStorage.setItem(
           'trackingData',
           JSON.stringify({
+            repo: repo || file.name,
             branches: ['main'],
             offsets: { main: { x: 0, y: 0, z: 0 } },
             domains: { main: 'other' },


### PR DESCRIPTION
## Summary
- adjust orthographic camera zoom constants for front view to properly align commits with grid sections
- reuse stored tracking data to load ingested repos without hitting GitHub APIs
- gracefully handle LLM failures during ingestion, returning default analysis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c650b029108322879852bcea1e14b2